### PR TITLE
Switch to major minor for build BCI image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4.27.14.36 AS build
+FROM registry.suse.com/bci/bci-base:15.4 AS build
 
 ARG ARCH
 ARG KUBERNETES_RELEASE=v1.21.3


### PR DESCRIPTION
As this container is only used as build container, we can just use `15.4` and avoid having to update the full version every time a new one is released. As we only copy the downloaded binary and two text files, there is no way that a vulnerability can go from the build container into the resulting container.