### PR TITLE
Retry curl check for version binaries

### DIFF
--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -7,7 +7,7 @@ for release in $(cat versions.txt); do
   for arch in $archs; do
     KUBECTL_URL="https://dl.k8s.io/release/${release}/bin/linux/${arch}/kubectl"
     echo "Checking if file exists at ${KUBECTL_URL}"
-    curl -L -o /dev/null -sS --fail "${KUBECTL_URL}"
+    curl --retry 10 --retry-connrefused -L -o /dev/null -sS --fail "${KUBECTL_URL}"
   done
 done
 


### PR DESCRIPTION
Fix for issue seen in https://drone-pr.rancher.io/rancher/kubectl/71/1/2:

```
Checking if file exists at https://dl.k8s.io/release/v1.26.5/bin/linux/s390x/kubectl
curl: (18) Recv failure: Connection reset by peer
time="2023-10-12T08:53:43Z" level=fatal msg="exit status 18"
```