### PR TITLE
[BUG] Fixes GHA issue where kubectl version isn't correct

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,6 +88,8 @@ jobs:
           push: true
           tags: ${{ env.IMAGE_REPO }}:${{ matrix.version }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            KUBERNETES_RELEASE=${{ matrix.version }}
       - name: Get CPU Arch hashes
         run: |
           docker manifest inspect ${{ env.IMAGE_REPO }}:${{ matrix.version }} | jq --raw-output '.manifests[]


### PR DESCRIPTION
Per title, this fix corrects a pretty big oversight I made in the process of migrating to GHA.
Fortunately the build process has only executed a single time since merging the new workflows.

# Scope

So the only items affected by this issue are:

- v1.30.0
- v1.29.4
- v1.28.9
- v1.27.13

None of which are in use by us in charts yet.

## Fixes

Because thankfully none of the affected tags are being used yet, we can fix this pretty easily and quietly.

To correct this we have 2 main options:

1. If we can repush images, we can simply make a temporary GHA workflow to republish these 4. Upon re-pushing to Docker hub the issue will be resolved.

2. Ask EIO to delete these tags in docker, run the normal publish action which will see the missing images.