### PR TITLE
Fix issue reading values from prior step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,7 @@ jobs:
       contents: read
       id-token: write # this is important, it's how we authenticate with Vault
     needs:
+      - image-prebuild
       - image-prebuild-validate
     name: Build and push Image(s)
     runs-on: ubuntu-latest


### PR DESCRIPTION
So the final error with our GHA workflow is:

> Error when evaluating 'strategy' for job 'image-build-push'. .github/workflows/publish.yml (Line: 104, Col: 18): Error parsing fromJson,.github/workflows/publish.yml (Line: 104, Col: 18): Error reading JToken from JsonReader. Path '', line 0, position 0.,.github/workflows/publish.yml (Line: 104, Col: 18): Unexpected value ''

And it was caused by me forgetting that you need to declare previous steps in the `needs` field if you want to read the output of those steps. So by making this change it should correct this issue and these unpublished images should be published.