### PR TITLE
Replaced AppCo by the official product name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ And. That. Is. It.
 
 > [!WARNING]
 > This image was an internal component of various Rancher Projects and has recently been deprecated.
-> Any external consumers of this image should migrate to another image, like the [Kubectl image from AppCo](https://apps.rancher.io/applications/kubectl).
+> Any external consumers of this image should migrate to another image, like the [Kubectl image from SUSE Application Collection](https://apps.rancher.io/applications/kubectl).
 > 
 > For Rancher projects we are migrating to `rancher/kuberlr-kubectl` based image, for assistance reach out to Team ORBS.
 


### PR DESCRIPTION
This is a minor change to replace `AppCo` by the official product name.